### PR TITLE
Add link to CLI-over-MCP community knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Beyond filtering, CLI gives you:
 | **Script**         | Save to .sh, version control  | Ephemeral              |
 | **Human takeover** | Same commands                 | Different interface    |
 
+*See also: [MCP Considered Suboptimal](https://github.com/kb4ai/mcp-considered-suboptimal-pub-kb) — a community knowledge base collecting CLI-over-MCP patterns and alternatives.*
+
 ---
 
 ## Agent Integration


### PR DESCRIPTION
AI Assistant:

## Summary

Adds a small "See also" link after the CLI vs MCP comparison table in the README, pointing to a community knowledge base that collects CLI-over-MCP patterns and alternatives.

The link is placed naturally after the comparison table where readers are already thinking about CLI advantages — a single line, easy to ignore if not interesting.

## Changes

* One line added to README.md after the CLI vs MCP table

## Context

Related to #17 — your README's articulation of "who controls what enters context" is excellent and we've been referencing it. This PR is entirely optional and offered for your convenience. Feel free to close if you'd rather not add external links.

---
*🤖 Generated with [Claude Code](https://claude.com/claude-code)*